### PR TITLE
fix: Replace creator property with sender (room v11 spec)

### DIFF
--- a/src/convenience.mjs
+++ b/src/convenience.mjs
@@ -51,7 +51,7 @@ const roomStateReducer = (acc, event) => {
     case 'm.room.create': {
       acc.type = (event.content?.type) ? event.content.type : 'm.room'
       acc.id = event.content['io.syncpoint.odin.id']
-      acc.creator = event.sender
+      acc.sender = event.sender
       break 
     }
     case 'm.room.name': { acc.name = event.content.name; break }

--- a/src/project.mjs
+++ b/src/project.mjs
@@ -90,7 +90,7 @@ Project.prototype.hydrate = async function ({ id, upstreamId }) {
     },
     topic: hierarchy.topic,
     layers: Object.values(hierarchy.layers).map(layer => ({
-      creator: layer.creator,
+      sender: layer.sender,
       id: layer.id,
       name: layer.name,
       role: {


### PR DESCRIPTION
## Summary

Fixes #4 — The `creator` property was removed from `m.room.create` events in [room version 11](https://spec.matrix.org/v1.9/rooms/v11/#remove-the-creator-property-of-mroomcreate-events).

## Changes

The code already correctly used `event.sender` (not `event.content.creator`) in `roomStateReducer`, but stored the value under the property name `creator`. This PR renames it to `sender` for spec alignment:

- `convenience.mjs`: `acc.creator = event.sender` → `acc.sender = event.sender`
- `project.mjs`: `creator: layer.creator` → `sender: layer.sender` in hydrate output

## Impact

- ODINv2 does not reference `.creator` from the matrix-client-api return objects (verified via grep)
- 40 unit tests passing