### PR TITLE
feat: Persistent command queue backed by LevelDB

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -35,6 +35,7 @@ const client = MatrixClient({
   home_server_url: 'https://matrix.example.com',
   user_id: '@alice:example.com',
   password: 'secret',
+  db: commandQueueDB,                 // levelup-compatible DB for persistent command queue
   encryption: { enabled: true }       // optional: enable E2EE
 })
 
@@ -90,11 +91,42 @@ project.start(null, {
 
 **StructureAPI** — Creates and queries ODIN structural components: projects (Matrix spaces) and layers (Matrix rooms). Handles invitations, joins, power levels, and room hierarchy.
 
-**CommandAPI** — Send-only API with ordered queue. Schedules ODIN operations for delivery. Transparently encrypts messages when E2EE is enabled. Supports async callback functions in the queue for post-send actions.
+**CommandAPI** — Send-only API with persistent ordered queue. Schedules ODIN operations for delivery and persists them to LevelDB so they survive restarts. Transparently encrypts messages when E2EE is enabled. Supports async callback functions in the queue for post-send actions.
 
 **TimelineAPI** — Receive-only API. Consumes the Matrix sync stream and message history. Transparently decrypts incoming events. Provides both initial catch-up (via `/messages`) and live streaming (via `/sync` long-poll).
 
 **CryptoManager** — Wraps the `@matrix-org/matrix-sdk-crypto-wasm` OlmMachine. Handles key upload, device tracking, Olm/Megolm session management, and historical key sharing.
+
+## Persistent Command Queue
+
+The CommandAPI uses a LevelDB-backed FIFO queue to persist pending commands. Operations survive ODIN restarts and Electron reloads.
+
+### How It Works
+
+1. When `schedule()` is called, the command is written to LevelDB and enqueued in memory.
+2. The `run()` loop dequeues and sends commands via HTTP.
+3. After successful delivery, `acknowledge()` removes the entry from the database.
+4. If ODIN crashes before acknowledge, the entry remains in the database and is restored on next startup.
+5. Matrix `sendMessageEvent` with `txnId` is idempotent, so duplicate sends after crash recovery are safe.
+
+Callback functions (e.g. for historical key sharing) are held in-memory only and are not persisted, as they are covered by existing safety nets in the crypto layer.
+
+### Setup
+
+The queue requires a `levelup`-compatible database instance, injected via the `db` property:
+
+```javascript
+import subleveldown from 'subleveldown'
+
+const commandQueueDB = subleveldown(odinDB, 'command-queue', { valueEncoding: 'json' })
+
+const client = MatrixClient({
+  home_server_url: 'https://matrix.example.com',
+  user_id: '@alice:example.com',
+  password: 'secret',
+  db: commandQueueDB
+})
+```
 
 ## End-to-End Encryption
 
@@ -128,9 +160,10 @@ const client = MatrixClient({
   home_server_url: 'https://matrix.example.com',
   user_id: '@alice:example.com',
   password: 'secret',
+  db: commandQueueDB,                      // levelup-compatible DB for persistent command queue
   encryption: {
     enabled: true,
-    storeName: 'crypto-<projectUUID>',    // persistent IndexedDB store (Electron/browser)
+    storeName: 'crypto-<projectUUID>',     // persistent IndexedDB store (Electron/browser)
     passphrase: 'optional-store-passphrase'
   }
 })

--- a/index.mjs
+++ b/index.mjs
@@ -42,6 +42,7 @@ const connect = (home_server_url) => async (controller) => {
  * @property {boolean} [encryption.enabled=false] - Enable E2EE
  * @property {string} [encryption.storeName] - IndexedDB store name for persistent crypto state (e.g. 'crypto-<projectUUID>')
  * @property {string} [encryption.passphrase] - Passphrase to encrypt the IndexedDB store
+ * @property {Object} db - A levelup-compatible database instance for the persistent command queue
  * 
  * @param {LoginData} loginData 
  * @returns {Object} matrixClient
@@ -119,7 +120,7 @@ const MatrixClient = (loginData) => {
       const projectParams = {
         structureAPI: new StructureAPI(httpAPI),
         timelineAPI: new TimelineAPI(httpAPI, crypto),
-        commandAPI: new CommandAPI(httpAPI, crypto?.cryptoManager || null),
+        commandAPI: new CommandAPI(httpAPI, crypto?.cryptoManager || null, loginData.db),
         cryptoManager: crypto?.cryptoManager || null
       }
       const project = new Project(projectParams)

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,10 @@
       },
       "devDependencies": {
         "@faker-js/faker": "^7.6.0",
-        "memory-level": "^3.1.0",
-        "mocha": "^10.2.0"
+        "levelup": "^5.1.1",
+        "memdown": "^6.1.1",
+        "mocha": "^10.2.0",
+        "subleveldown": "^6.0.1"
       }
     },
     "node_modules/@faker-js/faker": {
@@ -38,32 +40,23 @@
         "node": ">= 18"
       }
     },
-    "node_modules/abstract-level": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-3.1.1.tgz",
-      "integrity": "sha512-CW2gKbJFTuX1feMvOrvsVMmijAOgI9kg2Ie9Dq3gOcMt/dVVoVmqNlLcEUCT13NxHFMEajcUcVBIplbyDroDiw==",
+    "node_modules/abstract-leveldown": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz",
+      "integrity": "sha512-DnhQwcFEaYsvYDnACLZhMmCWd3rkOeEvglpa4q5i/5Jlm3UIsWaxVzuXvDLFCSCWRO3yy2/+V/G7FusFgejnfQ==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3",
+        "catering": "^2.0.0",
         "is-buffer": "^2.0.5",
-        "level-supports": "^6.2.0",
-        "level-transcoder": "^1.0.1",
-        "maybe-combine-errors": "^1.0.0",
-        "module-error": "^1.0.1"
+        "level-concat-iterator": "^3.0.0",
+        "level-supports": "^2.0.1",
+        "queue-microtask": "^1.2.3"
       },
       "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/abstract-level/node_modules/level-supports": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-6.2.0.tgz",
-      "integrity": "sha512-QNxVXP0IRnBmMsJIh+sb2kwNCYcKciQZJEt+L1hPCHrKNELllXhvrlClVHXBYZVT+a7aTSM6StgNXdAldoab3w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
+        "node": ">=10"
       }
     },
     "node_modules/ansi-colors": {
@@ -219,6 +212,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/catering": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
+      "integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -344,6 +347,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/deferred-leveldown": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-7.0.0.tgz",
+      "integrity": "sha512-QKN8NtuS3BC6m0B8vAnBls44tX1WXAFATUsJlruyAYbZpysWV3siH6o/i3g9DCHauzodksO60bdj5NazNbjCmg==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abstract-leveldown": "^7.2.0",
+        "inherits": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/defined": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
+      "integrity": "sha512-zpqiCT8bODLu3QSmLLic8xJnYWBFjOSu/fBCm189oAiTtPq/PSanNACKZDS7kgSyCJY7P+IcODzlIogBK/9RBg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/diff": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -358,6 +383,23 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "node_modules/encoding-down": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-7.1.0.tgz",
+      "integrity": "sha512-ky47X5jP84ryk5EQmvedQzELwVJPjCgXDQZGeb9F6r4PdChByCGHTBrVcF3h8ynKVJ1wVbkxTsDC8zBROPypgQ==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abstract-leveldown": "^7.2.0",
+        "inherits": "^2.0.3",
+        "level-codec": "^10.0.0",
+        "level-errors": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -689,18 +731,96 @@
         "url": "https://github.com/sindresorhus/ky?sponsor=1"
       }
     },
-    "node_modules/level-transcoder": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/level-transcoder/-/level-transcoder-1.0.1.tgz",
-      "integrity": "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==",
+    "node_modules/level-codec": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-10.0.0.tgz",
+      "integrity": "sha512-QW3VteVNAp6c/LuV6nDjg7XDXx9XHK4abmQarxZmlRSDyXYk20UdaJTSX6yzVvQ4i0JyWSB7jert0DsyD/kk6g==",
+      "deprecated": "Superseded by level-transcoder (https://github.com/Level/community#faq)",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "buffer": "^6.0.3",
-        "module-error": "^1.0.1"
+        "buffer": "^6.0.3"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=10"
+      }
+    },
+    "node_modules/level-concat-iterator": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-3.1.0.tgz",
+      "integrity": "sha512-BWRCMHBxbIqPxJ8vHOvKUsaO0v1sLYZtjN3K2iZJsRBYtp+ONsY6Jfi6hy9K3+zolgQRryhIn2NRZjZnWJ9NmQ==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "catering": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/level-errors": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-3.0.1.tgz",
+      "integrity": "sha512-tqTL2DxzPDzpwl0iV5+rBCv65HWbHp6eutluHNcVIftKZlQN//b6GEnZDM2CvGZvzGYMwyPtYppYnydBQd2SMQ==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/level-iterator-stream": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-5.0.0.tgz",
+      "integrity": "sha512-wnb1+o+CVFUDdiSMR/ZymE2prPs3cjVLlXuDeSq9Zb8o032XrabGEXcTCsBxprAtseO3qvFeGzh6406z9sOTRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/level-option-wrap": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/level-option-wrap/-/level-option-wrap-1.1.0.tgz",
+      "integrity": "sha512-gQouC22iCqHuBLNl4BHxEZUxLvUKALAtT/Q0c6ziOxZQ8c02G/gyxHWNbLbxUzRNfMrRnbt6TZT3gNe8VBqQeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defined": "~0.0.0"
+      }
+    },
+    "node_modules/level-supports": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
+      "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/levelup": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-5.1.1.tgz",
+      "integrity": "sha512-0mFCcHcEebOwsQuk00WJwjLI6oCjbBuEYdh/RaRqhjnyVlzqf41T1NnDtCedumZ56qyIh8euLFDqV1KfzTAVhg==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "catering": "^2.0.0",
+        "deferred-leveldown": "^7.0.0",
+        "level-errors": "^3.0.1",
+        "level-iterator-stream": "^5.0.0",
+        "level-supports": "^2.0.1",
+        "queue-microtask": "^1.2.3"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/locate-path": {
@@ -734,29 +854,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/maybe-combine-errors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/maybe-combine-errors/-/maybe-combine-errors-1.0.0.tgz",
-      "integrity": "sha512-eefp6IduNPT6fVdwPp+1NgD0PML1NU5P6j1Mj5nz1nidX8/sWY7119WL8vTAHgqfsY74TzW0w1XPgdYEKkGZ5A==",
+    "node_modules/ltgt": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+      "integrity": "sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
+      "license": "MIT"
     },
-    "node_modules/memory-level": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/memory-level/-/memory-level-3.1.0.tgz",
-      "integrity": "sha512-mTqFVi5iReKcjue/pag0OY4VNU7dlagCyjjPwWGierpk1Bpl9WjOxgXIswymPW3Q9bj3Foay+Z16mPGnKzvTkQ==",
+    "node_modules/memdown": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-6.1.1.tgz",
+      "integrity": "sha512-vh2RiuVrn6Vv73088C1KzLwy9+hhRwoZsgddYqIoVuFFrcoc2Rt+lq/KrmkFn6ulko7AtQ0AvqtYid35exb38A==",
+      "deprecated": "Superseded by memory-level (https://github.com/Level/community#faq)",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "abstract-level": "^3.1.0",
+        "abstract-leveldown": "^7.2.0",
+        "buffer": "^6.0.3",
         "functional-red-black-tree": "^1.0.1",
-        "module-error": "^1.0.1"
+        "inherits": "^2.0.1",
+        "ltgt": "^2.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=10"
       }
     },
     "node_modules/minimatch": {
@@ -809,16 +929,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mochajs"
-      }
-    },
-    "node_modules/module-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
-      "integrity": "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -917,6 +1027,27 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -924,6 +1055,31 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/reachdown": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reachdown/-/reachdown-1.1.0.tgz",
+      "integrity": "sha512-6LsdRe4cZyOjw4NnvbhUd/rGG7WQ9HMopPr+kyL018Uci4kijtxcGR5kVb5Ln13k4PEE+fEFQbjfOvNw7cnXmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/readdirp": {
@@ -976,6 +1132,16 @@
         "randombytes": "^2.1.0"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -1014,6 +1180,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/subleveldown": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/subleveldown/-/subleveldown-6.0.1.tgz",
+      "integrity": "sha512-Cnf+cn2wISXU2xflY1SFIqfX4hG2d6lFk2P5F8RDQLmiqN9Ir4ExNfUFH6xnmizMseM/t+nMsDUKjN9Kw6ShFA==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abstract-leveldown": "^7.2.0",
+        "encoding-down": "^7.1.0",
+        "inherits": "^2.0.3",
+        "level-option-wrap": "^1.1.0",
+        "levelup": "^5.1.1",
+        "reachdown": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -1041,6 +1226,13 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/workerpool": {
       "version": "6.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,8 @@
       },
       "devDependencies": {
         "@faker-js/faker": "^7.6.0",
-        "levelup": "^5.1.1",
-        "memdown": "^6.1.1",
-        "mocha": "^10.2.0",
-        "subleveldown": "^6.0.1"
+        "memory-level": "^3.1.0",
+        "mocha": "^10.2.0"
       }
     },
     "node_modules/@faker-js/faker": {
@@ -40,23 +38,32 @@
         "node": ">= 18"
       }
     },
-    "node_modules/abstract-leveldown": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz",
-      "integrity": "sha512-DnhQwcFEaYsvYDnACLZhMmCWd3rkOeEvglpa4q5i/5Jlm3UIsWaxVzuXvDLFCSCWRO3yy2/+V/G7FusFgejnfQ==",
-      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
+    "node_modules/abstract-level": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-3.1.1.tgz",
+      "integrity": "sha512-CW2gKbJFTuX1feMvOrvsVMmijAOgI9kg2Ie9Dq3gOcMt/dVVoVmqNlLcEUCT13NxHFMEajcUcVBIplbyDroDiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3",
-        "catering": "^2.0.0",
         "is-buffer": "^2.0.5",
-        "level-concat-iterator": "^3.0.0",
-        "level-supports": "^2.0.1",
-        "queue-microtask": "^1.2.3"
+        "level-supports": "^6.2.0",
+        "level-transcoder": "^1.0.1",
+        "maybe-combine-errors": "^1.0.0",
+        "module-error": "^1.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
+      }
+    },
+    "node_modules/abstract-level/node_modules/level-supports": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-6.2.0.tgz",
+      "integrity": "sha512-QNxVXP0IRnBmMsJIh+sb2kwNCYcKciQZJEt+L1hPCHrKNELllXhvrlClVHXBYZVT+a7aTSM6StgNXdAldoab3w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/ansi-colors": {
@@ -212,16 +219,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/catering": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
-      "integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -347,28 +344,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/deferred-leveldown": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-7.0.0.tgz",
-      "integrity": "sha512-QKN8NtuS3BC6m0B8vAnBls44tX1WXAFATUsJlruyAYbZpysWV3siH6o/i3g9DCHauzodksO60bdj5NazNbjCmg==",
-      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "abstract-leveldown": "^7.2.0",
-        "inherits": "^2.0.3"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/defined": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
-      "integrity": "sha512-zpqiCT8bODLu3QSmLLic8xJnYWBFjOSu/fBCm189oAiTtPq/PSanNACKZDS7kgSyCJY7P+IcODzlIogBK/9RBg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/diff": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -383,23 +358,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
-    },
-    "node_modules/encoding-down": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-7.1.0.tgz",
-      "integrity": "sha512-ky47X5jP84ryk5EQmvedQzELwVJPjCgXDQZGeb9F6r4PdChByCGHTBrVcF3h8ynKVJ1wVbkxTsDC8zBROPypgQ==",
-      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "abstract-leveldown": "^7.2.0",
-        "inherits": "^2.0.3",
-        "level-codec": "^10.0.0",
-        "level-errors": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -731,96 +689,18 @@
         "url": "https://github.com/sindresorhus/ky?sponsor=1"
       }
     },
-    "node_modules/level-codec": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-10.0.0.tgz",
-      "integrity": "sha512-QW3VteVNAp6c/LuV6nDjg7XDXx9XHK4abmQarxZmlRSDyXYk20UdaJTSX6yzVvQ4i0JyWSB7jert0DsyD/kk6g==",
-      "deprecated": "Superseded by level-transcoder (https://github.com/Level/community#faq)",
+    "node_modules/level-transcoder": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/level-transcoder/-/level-transcoder-1.0.1.tgz",
+      "integrity": "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "buffer": "^6.0.3"
+        "buffer": "^6.0.3",
+        "module-error": "^1.0.1"
       },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/level-concat-iterator": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-3.1.0.tgz",
-      "integrity": "sha512-BWRCMHBxbIqPxJ8vHOvKUsaO0v1sLYZtjN3K2iZJsRBYtp+ONsY6Jfi6hy9K3+zolgQRryhIn2NRZjZnWJ9NmQ==",
-      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "catering": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/level-errors": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-3.0.1.tgz",
-      "integrity": "sha512-tqTL2DxzPDzpwl0iV5+rBCv65HWbHp6eutluHNcVIftKZlQN//b6GEnZDM2CvGZvzGYMwyPtYppYnydBQd2SMQ==",
-      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/level-iterator-stream": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-5.0.0.tgz",
-      "integrity": "sha512-wnb1+o+CVFUDdiSMR/ZymE2prPs3cjVLlXuDeSq9Zb8o032XrabGEXcTCsBxprAtseO3qvFeGzh6406z9sOTRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/level-option-wrap": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/level-option-wrap/-/level-option-wrap-1.1.0.tgz",
-      "integrity": "sha512-gQouC22iCqHuBLNl4BHxEZUxLvUKALAtT/Q0c6ziOxZQ8c02G/gyxHWNbLbxUzRNfMrRnbt6TZT3gNe8VBqQeg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "defined": "~0.0.0"
-      }
-    },
-    "node_modules/level-supports": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
-      "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/levelup": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-5.1.1.tgz",
-      "integrity": "sha512-0mFCcHcEebOwsQuk00WJwjLI6oCjbBuEYdh/RaRqhjnyVlzqf41T1NnDtCedumZ56qyIh8euLFDqV1KfzTAVhg==",
-      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "catering": "^2.0.0",
-        "deferred-leveldown": "^7.0.0",
-        "level-errors": "^3.0.1",
-        "level-iterator-stream": "^5.0.0",
-        "level-supports": "^2.0.1",
-        "queue-microtask": "^1.2.3"
-      },
-      "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/locate-path": {
@@ -854,29 +734,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/ltgt": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
-      "integrity": "sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA==",
+    "node_modules/maybe-combine-errors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/maybe-combine-errors/-/maybe-combine-errors-1.0.0.tgz",
+      "integrity": "sha512-eefp6IduNPT6fVdwPp+1NgD0PML1NU5P6j1Mj5nz1nidX8/sWY7119WL8vTAHgqfsY74TzW0w1XPgdYEKkGZ5A==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
-    "node_modules/memdown": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/memdown/-/memdown-6.1.1.tgz",
-      "integrity": "sha512-vh2RiuVrn6Vv73088C1KzLwy9+hhRwoZsgddYqIoVuFFrcoc2Rt+lq/KrmkFn6ulko7AtQ0AvqtYid35exb38A==",
-      "deprecated": "Superseded by memory-level (https://github.com/Level/community#faq)",
+    "node_modules/memory-level": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/memory-level/-/memory-level-3.1.0.tgz",
+      "integrity": "sha512-mTqFVi5iReKcjue/pag0OY4VNU7dlagCyjjPwWGierpk1Bpl9WjOxgXIswymPW3Q9bj3Foay+Z16mPGnKzvTkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "abstract-leveldown": "^7.2.0",
-        "buffer": "^6.0.3",
+        "abstract-level": "^3.1.0",
         "functional-red-black-tree": "^1.0.1",
-        "inherits": "^2.0.1",
-        "ltgt": "^2.2.0"
+        "module-error": "^1.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/minimatch": {
@@ -929,6 +809,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mochajs"
+      }
+    },
+    "node_modules/module-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
+      "integrity": "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -1027,27 +917,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -1055,31 +924,6 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
-      }
-    },
-    "node_modules/reachdown": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reachdown/-/reachdown-1.1.0.tgz",
-      "integrity": "sha512-6LsdRe4cZyOjw4NnvbhUd/rGG7WQ9HMopPr+kyL018Uci4kijtxcGR5kVb5Ln13k4PEE+fEFQbjfOvNw7cnXmA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/readdirp": {
@@ -1132,16 +976,6 @@
         "randombytes": "^2.1.0"
       }
     },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -1180,25 +1014,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/subleveldown": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/subleveldown/-/subleveldown-6.0.1.tgz",
-      "integrity": "sha512-Cnf+cn2wISXU2xflY1SFIqfX4hG2d6lFk2P5F8RDQLmiqN9Ir4ExNfUFH6xnmizMseM/t+nMsDUKjN9Kw6ShFA==",
-      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "abstract-leveldown": "^7.2.0",
-        "encoding-down": "^7.1.0",
-        "inherits": "^2.0.3",
-        "level-option-wrap": "^1.1.0",
-        "levelup": "^5.1.1",
-        "reachdown": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -1226,13 +1041,6 @@
       "engines": {
         "node": ">=8.0"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/workerpool": {
       "version": "6.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,10 @@
       },
       "devDependencies": {
         "@faker-js/faker": "^7.6.0",
-        "mocha": "^10.2.0"
+        "levelup": "^5.1.1",
+        "memdown": "^6.1.1",
+        "mocha": "^10.2.0",
+        "subleveldown": "^6.0.1"
       }
     },
     "node_modules/@faker-js/faker": {
@@ -35,6 +38,25 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/abstract-leveldown": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz",
+      "integrity": "sha512-DnhQwcFEaYsvYDnACLZhMmCWd3rkOeEvglpa4q5i/5Jlm3UIsWaxVzuXvDLFCSCWRO3yy2/+V/G7FusFgejnfQ==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "catering": "^2.0.0",
+        "is-buffer": "^2.0.5",
+        "level-concat-iterator": "^3.0.0",
+        "level-supports": "^2.0.1",
+        "queue-microtask": "^1.2.3"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ansi-colors": {
@@ -95,6 +117,27 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -132,6 +175,31 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/camelcase": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -142,6 +210,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/catering": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
+      "integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/chalk": {
@@ -269,6 +347,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/deferred-leveldown": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-7.0.0.tgz",
+      "integrity": "sha512-QKN8NtuS3BC6m0B8vAnBls44tX1WXAFATUsJlruyAYbZpysWV3siH6o/i3g9DCHauzodksO60bdj5NazNbjCmg==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abstract-leveldown": "^7.2.0",
+        "inherits": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/defined": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
+      "integrity": "sha512-zpqiCT8bODLu3QSmLLic8xJnYWBFjOSu/fBCm189oAiTtPq/PSanNACKZDS7kgSyCJY7P+IcODzlIogBK/9RBg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/diff": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -283,6 +383,23 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "node_modules/encoding-down": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-7.1.0.tgz",
+      "integrity": "sha512-ky47X5jP84ryk5EQmvedQzELwVJPjCgXDQZGeb9F6r4PdChByCGHTBrVcF3h8ynKVJ1wVbkxTsDC8zBROPypgQ==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abstract-leveldown": "^7.2.0",
+        "inherits": "^2.0.3",
+        "level-codec": "^10.0.0",
+        "level-errors": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -362,6 +479,13 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -444,6 +568,27 @@
         "he": "bin/he"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -470,6 +615,30 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/is-extglob": {
@@ -562,6 +731,98 @@
         "url": "https://github.com/sindresorhus/ky?sponsor=1"
       }
     },
+    "node_modules/level-codec": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-10.0.0.tgz",
+      "integrity": "sha512-QW3VteVNAp6c/LuV6nDjg7XDXx9XHK4abmQarxZmlRSDyXYk20UdaJTSX6yzVvQ4i0JyWSB7jert0DsyD/kk6g==",
+      "deprecated": "Superseded by level-transcoder (https://github.com/Level/community#faq)",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/level-concat-iterator": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-3.1.0.tgz",
+      "integrity": "sha512-BWRCMHBxbIqPxJ8vHOvKUsaO0v1sLYZtjN3K2iZJsRBYtp+ONsY6Jfi6hy9K3+zolgQRryhIn2NRZjZnWJ9NmQ==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "catering": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/level-errors": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-3.0.1.tgz",
+      "integrity": "sha512-tqTL2DxzPDzpwl0iV5+rBCv65HWbHp6eutluHNcVIftKZlQN//b6GEnZDM2CvGZvzGYMwyPtYppYnydBQd2SMQ==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/level-iterator-stream": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-5.0.0.tgz",
+      "integrity": "sha512-wnb1+o+CVFUDdiSMR/ZymE2prPs3cjVLlXuDeSq9Zb8o032XrabGEXcTCsBxprAtseO3qvFeGzh6406z9sOTRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/level-option-wrap": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/level-option-wrap/-/level-option-wrap-1.1.0.tgz",
+      "integrity": "sha512-gQouC22iCqHuBLNl4BHxEZUxLvUKALAtT/Q0c6ziOxZQ8c02G/gyxHWNbLbxUzRNfMrRnbt6TZT3gNe8VBqQeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defined": "~0.0.0"
+      }
+    },
+    "node_modules/level-supports": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
+      "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/levelup": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-5.1.1.tgz",
+      "integrity": "sha512-0mFCcHcEebOwsQuk00WJwjLI6oCjbBuEYdh/RaRqhjnyVlzqf41T1NnDtCedumZ56qyIh8euLFDqV1KfzTAVhg==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "catering": "^2.0.0",
+        "deferred-leveldown": "^7.0.0",
+        "level-errors": "^3.0.1",
+        "level-iterator-stream": "^5.0.0",
+        "level-supports": "^2.0.1",
+        "queue-microtask": "^1.2.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -591,6 +852,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ltgt": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+      "integrity": "sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/memdown": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-6.1.1.tgz",
+      "integrity": "sha512-vh2RiuVrn6Vv73088C1KzLwy9+hhRwoZsgddYqIoVuFFrcoc2Rt+lq/KrmkFn6ulko7AtQ0AvqtYid35exb38A==",
+      "deprecated": "Superseded by memory-level (https://github.com/Level/community#faq)",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abstract-leveldown": "^7.2.0",
+        "buffer": "^6.0.3",
+        "functional-red-black-tree": "^1.0.1",
+        "inherits": "^2.0.1",
+        "ltgt": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/minimatch": {
@@ -741,6 +1027,27 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -748,6 +1055,31 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/reachdown": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reachdown/-/reachdown-1.1.0.tgz",
+      "integrity": "sha512-6LsdRe4cZyOjw4NnvbhUd/rGG7WQ9HMopPr+kyL018Uci4kijtxcGR5kVb5Ln13k4PEE+fEFQbjfOvNw7cnXmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/readdirp": {
@@ -800,6 +1132,16 @@
         "randombytes": "^2.1.0"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -838,6 +1180,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/subleveldown": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/subleveldown/-/subleveldown-6.0.1.tgz",
+      "integrity": "sha512-Cnf+cn2wISXU2xflY1SFIqfX4hG2d6lFk2P5F8RDQLmiqN9Ir4ExNfUFH6xnmizMseM/t+nMsDUKjN9Kw6ShFA==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abstract-leveldown": "^7.2.0",
+        "encoding-down": "^7.1.0",
+        "inherits": "^2.0.3",
+        "level-option-wrap": "^1.1.0",
+        "levelup": "^5.1.1",
+        "reachdown": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -865,6 +1226,13 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/workerpool": {
       "version": "6.2.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",
-    "memory-level": "^3.1.0",
-    "mocha": "^10.2.0"
+    "levelup": "^5.1.1",
+    "memdown": "^6.1.1",
+    "mocha": "^10.2.0",
+    "subleveldown": "^6.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,9 +21,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",
-    "levelup": "^5.1.1",
-    "memdown": "^6.1.1",
-    "mocha": "^10.2.0",
-    "subleveldown": "^6.0.1"
+    "memory-level": "^3.1.0",
+    "mocha": "^10.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",
-    "mocha": "^10.2.0"
+    "levelup": "^5.1.1",
+    "memdown": "^6.1.1",
+    "mocha": "^10.2.0",
+    "subleveldown": "^6.0.1"
   }
 }

--- a/src/command-api.mjs
+++ b/src/command-api.mjs
@@ -5,11 +5,12 @@ class CommandAPI {
   /**
    * @param {import('./http-api.mjs').HttpAPI} httpAPI
    * @param {import('./crypto.mjs').CryptoManager} [cryptoManager] - Optional CryptoManager for E2EE
+   * @param {Object} db - A levelup-compatible database instance for persistent queue storage
    */
-  constructor (httpAPI, cryptoManager) {
+  constructor (httpAPI, cryptoManager, db) {
     this.httpAPI = httpAPI
     this.cryptoManager = cryptoManager || null
-    this.scheduledCalls = new FIFO()
+    this.scheduledCalls = new FIFO(db)
   }
 
   /**
@@ -51,13 +52,14 @@ class CommandAPI {
     this.controller = new AbortController()
     
     let retryCounter = 0
-    let functionCall
+    let entry
 
     while (!this.controller.signal.aborted) {
       try {
         await chill(retryCounter)
 
-        functionCall = await this.scheduledCalls.dequeue()
+        entry = await this.scheduledCalls.dequeue()
+        let { command: functionCall, key } = entry
         let [functionName, ...params] = functionCall
 
         // Execute callback functions scheduled in the queue
@@ -134,6 +136,7 @@ class CommandAPI {
         }
 
         await this.httpAPI[functionName].apply(this.httpAPI, params)
+        await this.scheduledCalls.acknowledge(key)
         const log = getLogger()
         log.debug('Command sent:', functionName)
         retryCounter = 0
@@ -141,14 +144,14 @@ class CommandAPI {
         const log = getLogger()
         log.warn('Command failed:', error.message)
         if (error.response?.statusCode === 403) {
-          log.error('Command forbidden:', functionCall[0], error.response.body)
+          log.error('Command forbidden:', entry.command[0], error.response.body)
         }
         
         /*
           In most cases we will have to deal with socket errors. The users computer may
           be offline or the server might be unreachable.
         */
-        this.scheduledCalls.requeue(functionCall)
+        this.scheduledCalls.requeue(entry.command, entry.key)
         retryCounter++
       }
     }    

--- a/src/command-api.mjs
+++ b/src/command-api.mjs
@@ -59,7 +59,7 @@ class CommandAPI {
         await chill(retryCounter)
 
         entry = await this.scheduledCalls.dequeue()
-        let { command: functionCall, key } = entry
+        const { command: functionCall, key } = entry
         let [functionName, ...params] = functionCall
 
         // Execute callback functions scheduled in the queue

--- a/src/queue.mjs
+++ b/src/queue.mjs
@@ -1,66 +1,163 @@
+import { getLogger } from './logger.mjs'
+
+const KEY_PREFIX = 'cmd:'
+const COUNTER_KEY = '_counter'
+const PAD_LENGTH = 16
+
+/**
+ * Format a numeric counter as a zero-padded key.
+ * @param {number} n
+ * @returns {string}
+ */
+const formatKey = n => `${KEY_PREFIX}${String(n).padStart(PAD_LENGTH, '0')}`
+
+/**
+ * Parse the numeric counter from a key.
+ * @param {string} key
+ * @returns {number}
+ */
+const parseKey = key => Number(key.slice(KEY_PREFIX.length))
+
+/**
+ * A persistent FIFO queue backed by a LevelDB instance (levelup/subleveldown API).
+ *
+ * Serializable commands (arrays with string function name) are persisted to disk.
+ * Non-serializable commands (callbacks) are held in memory only.
+ *
+ * The queue resolves dequeue() calls in FIFO order, mixing persistent and
+ * in-memory entries by insertion order.
+ */
 class FIFO {
-  /*
-    Dequeue will create a promise that enqueue/requeue will resolve.
-    Credits to https://stackoverflow.com/questions/47157428/how-to-implement-a-pseudo-blocking-async-queue-in-js-ts/47157577#47157577
-  */
-  constructor() {
-    this.resolvingFunctions = []
-    this.promises = []
+  /**
+   * @param {Object} db - A levelup-compatible database instance (e.g. subleveldown)
+   */
+  constructor (db) {
+    this.db = db
+    this.counter = 0
+    this.pendingResolvers = []
+    this.pendingPromises = []
+    this._ready = this._restore()
   }
 
-  _add() {
-    this.promises.push(new Promise(resolve => {
-      this.resolvingFunctions.push(resolve)
+  /**
+   * Restore pending commands from the database on startup.
+   * @private
+   */
+  async _restore () {
+    const log = getLogger()
+    const entries = []
+
+    await new Promise((resolve, reject) => {
+      const stream = this.db.createReadStream({ gte: `${KEY_PREFIX}0`, lte: `${KEY_PREFIX}\xFF` })
+      stream.on('data', ({ key, value }) => {
+        const seq = parseKey(typeof key === 'string' ? key : key.toString())
+        const command = typeof value === 'string' ? JSON.parse(value) : value
+        entries.push({ seq, key: typeof key === 'string' ? key : key.toString(), command })
+      })
+      stream.on('error', reject)
+      stream.on('end', resolve)
+    })
+
+    // Restore the counter (persisted separately to survive acknowledge)
+    try {
+      const savedCounter = await this.db.get(COUNTER_KEY)
+      this.counter = typeof savedCounter === 'number' ? savedCounter : Number(savedCounter)
+    } catch (err) {
+      // Key not found — counter stays at 0
+    }
+
+    if (entries.length > 0) {
+      entries.sort((a, b) => a.seq - b.seq)
+      const maxSeq = entries[entries.length - 1].seq
+      if (maxSeq > this.counter) this.counter = maxSeq
+
+      for (const entry of entries) {
+        this._addPromise()
+        const resolve = this.pendingResolvers.shift()
+        resolve({ command: entry.command, key: entry.key })
+      }
+      log.info(`Restored ${entries.length} pending command(s) from persistent queue`)
+    }
+  }
+
+  /** @private */
+  _addPromise () {
+    this.pendingPromises.push(new Promise(resolve => {
+      this.pendingResolvers.push(resolve)
     }))
   }
 
-  enqueue(t) {
-    if (!this.resolvingFunctions.length) this._add()
-    // give me the heading resolving function, I'll call (resolve) it with parameter 't'
+  /**
+   * Add a command to the end of the queue.
+   * @param {Array} command - Function call as array: [functionName, ...params] or [callback]
+   */
+  async enqueue (command) {
+    await this._ready
+    const [functionName] = command
 
-    const resolve = this.resolvingFunctions.shift()
-    resolve(t)
+    let key = null
+    if (typeof functionName !== 'function') {
+      this.counter++
+      key = formatKey(this.counter)
+      await this.db.batch([
+        { type: 'put', key, value: JSON.stringify(command) },
+        { type: 'put', key: COUNTER_KEY, value: JSON.stringify(this.counter) }
+      ])
+    }
+
+    if (!this.pendingResolvers.length) this._addPromise()
+    const resolve = this.pendingResolvers.shift()
+    resolve({ command, key })
   }
 
-  dequeue() {
-    if (!this.promises.length) this._add()
-    return this.promises.shift()
+  /**
+   * Remove and return the next command from the queue.
+   * Blocks until a command is available.
+   * @returns {Promise<{command: Array, key: string|null}>}
+   */
+  async dequeue () {
+    await this._ready
+    if (!this.pendingPromises.length) this._addPromise()
+    return this.pendingPromises.shift()
   }
 
-  requeue(t) {
-    if (!this.promises.length) {
-      this._add()
+  /**
+   * Acknowledge successful processing — remove the entry from the database.
+   * @param {string|null} key - The database key, or null for in-memory-only entries
+   */
+  async acknowledge (key) {
+    if (key) {
+      await this.db.del(key)
+    }
+  }
+
+  /**
+   * Put a failed command back at the front of the queue.
+   * @param {Array} command
+   * @param {string|null} key - The database key (entry stays in DB until acknowledged)
+   */
+  requeue (command, key) {
+    if (!this.pendingPromises.length) {
+      this._addPromise()
     } else {
-      this.promises.unshift(new Promise(resolve => {
-        this.resolvingFunctions.unshift(resolve)
+      this.pendingPromises.unshift(new Promise(resolve => {
+        this.pendingResolvers.unshift(resolve)
       }))
     }
-    this.resolvingFunctions.shift()(t)
-  }
-  
-  isEmpty() {
-    return !this.promises.length
+    this.pendingResolvers.shift()({ command, key })
   }
 
-  isBlocked() {
-    return !!this.resolvingFunctions.length
+  isEmpty () {
+    return !this.pendingPromises.length
   }
 
-  get length() {
-    return this.promises.length - this.resolvingFunctions.length
+  isBlocked () {
+    return !!this.pendingResolvers.length
   }
 
-  [Symbol.asyncIterator]() {
-    return {
-      next: async () => {
-        const value = await this.dequeue()
-        return { done: false, value}
-      },
-      [Symbol.asyncIterator]() { return this }
-    }
+  get length () {
+    return this.pendingPromises.length - this.pendingResolvers.length
   }
 }
 
-export {
-  FIFO
-}
+export { FIFO }

--- a/src/queue.mjs
+++ b/src/queue.mjs
@@ -47,22 +47,17 @@ class FIFO {
     const log = getLogger()
     const entries = []
 
-    await new Promise((resolve, reject) => {
-      const stream = this.db.createReadStream({ gte: `${KEY_PREFIX}0`, lte: `${KEY_PREFIX}\xFF` })
-      stream.on('data', ({ key, value }) => {
-        const seq = parseKey(typeof key === 'string' ? key : key.toString())
-        const command = typeof value === 'string' ? JSON.parse(value) : value
-        entries.push({ seq, key: typeof key === 'string' ? key : key.toString(), command })
-      })
-      stream.on('error', reject)
-      stream.on('end', resolve)
-    })
+    const raw = await this.db.iterator({ gte: `${KEY_PREFIX}0`, lte: `${KEY_PREFIX}\xFF` }).all()
+    for (const [key, value] of raw) {
+      const seq = parseKey(key)
+      entries.push({ seq, key, command: value })
+    }
 
     // Restore the counter (persisted separately to survive acknowledge)
     try {
       const savedCounter = await this.db.get(COUNTER_KEY)
-      this.counter = typeof savedCounter === 'number' ? savedCounter : Number(savedCounter)
-    } catch (err) {
+      if (savedCounter != null) this.counter = Number(savedCounter)
+    } catch {
       // Key not found — counter stays at 0
     }
 
@@ -100,8 +95,8 @@ class FIFO {
       this.counter++
       key = formatKey(this.counter)
       await this.db.batch([
-        { type: 'put', key, value: JSON.stringify(command) },
-        { type: 'put', key: COUNTER_KEY, value: JSON.stringify(this.counter) }
+        { type: 'put', key, value: command },
+        { type: 'put', key: COUNTER_KEY, value: this.counter }
       ])
     }
 

--- a/src/queue.mjs
+++ b/src/queue.mjs
@@ -47,16 +47,23 @@ class FIFO {
     const log = getLogger()
     const entries = []
 
-    const raw = await this.db.iterator({ gte: `${KEY_PREFIX}0`, lte: `${KEY_PREFIX}\xFF` }).all()
-    for (const [key, value] of raw) {
-      const seq = parseKey(key)
-      entries.push({ seq, key, command: value })
-    }
+    await new Promise((resolve, reject) => {
+      const stream = this.db.createReadStream({ gte: `${KEY_PREFIX}0`, lte: `${KEY_PREFIX}\xFF` })
+      stream.on('data', ({ key, value }) => {
+        const k = typeof key === 'string' ? key : key.toString()
+        const seq = parseKey(k)
+        const command = typeof value === 'string' ? JSON.parse(value) : value
+        entries.push({ seq, key: k, command })
+      })
+      stream.on('error', reject)
+      stream.on('end', resolve)
+    })
 
     // Restore the counter (persisted separately to survive acknowledge)
     try {
       const savedCounter = await this.db.get(COUNTER_KEY)
-      if (savedCounter != null) this.counter = Number(savedCounter)
+      const parsed = typeof savedCounter === 'string' ? Number(JSON.parse(savedCounter)) : Number(savedCounter)
+      if (!isNaN(parsed)) this.counter = parsed
     } catch {
       // Key not found — counter stays at 0
     }
@@ -94,10 +101,12 @@ class FIFO {
     if (typeof functionName !== 'function') {
       this.counter++
       key = formatKey(this.counter)
-      await this.db.batch([
-        { type: 'put', key, value: command },
-        { type: 'put', key: COUNTER_KEY, value: this.counter }
-      ])
+      await new Promise((resolve, reject) => {
+        this.db.batch([
+          { type: 'put', key, value: JSON.stringify(command) },
+          { type: 'put', key: COUNTER_KEY, value: JSON.stringify(this.counter) }
+        ], err => err ? reject(err) : resolve())
+      })
     }
 
     if (!this.pendingResolvers.length) this._addPromise()
@@ -122,7 +131,9 @@ class FIFO {
    */
   async acknowledge (key) {
     if (key) {
-      await this.db.del(key)
+      await new Promise((resolve, reject) => {
+        this.db.del(key, err => err ? reject(err) : resolve())
+      })
     }
   }
 

--- a/test/queue.test.mjs
+++ b/test/queue.test.mjs
@@ -1,10 +1,13 @@
 import assert from 'node:assert/strict'
 import { describe, it, beforeEach } from 'mocha'
-import { MemoryLevel } from 'memory-level'
+import memdown from 'memdown'
+import levelup from 'levelup'
+import subleveldown from 'subleveldown'
 import { FIFO } from '../src/queue.mjs'
 
 const createDB = () => {
-  return new MemoryLevel({ valueEncoding: 'json' })
+  const db = levelup(memdown())
+  return subleveldown(db, 'command-queue', { valueEncoding: 'json' })
 }
 
 describe('Persistent FIFO Queue', function () {

--- a/test/queue.test.mjs
+++ b/test/queue.test.mjs
@@ -1,23 +1,153 @@
-/* import { FIFO } from '../src/queue.mjs'
+import assert from 'node:assert/strict'
+import { describe, it, beforeEach } from 'mocha'
+import memdown from 'memdown'
+import levelup from 'levelup'
+import subleveldown from 'subleveldown'
+import { FIFO } from '../src/queue.mjs'
 
-const jobs = new FIFO()
-
-Array.from([5, 6, 7, 8, 9, 10, 11]).forEach(m => 
-  
-  jobs.enqueue(m)
-)
-
-
-for await (const job of jobs) {
-  console.log(`Job ${job}`)
-  const choice = Math.random()
-  if (choice < 0.5) {
-    jobs.requeue(job)
-  }
+const createDB = () => {
+  const db = levelup(memdown())
+  return subleveldown(db, 'command-queue', { valueEncoding: 'json' })
 }
 
+describe('Persistent FIFO Queue', function () {
+  this.timeout(5000)
 
+  let db
 
+  beforeEach(() => {
+    db = createDB()
+  })
 
+  it('should enqueue and dequeue a command', async () => {
+    const queue = new FIFO(db)
+    await queue.enqueue(['sendMessageEvent', '!room:test', 'io.syncpoint.odin.operation', { content: 'abc' }])
 
- */
+    const { command, key } = await queue.dequeue()
+    assert.deepStrictEqual(command, ['sendMessageEvent', '!room:test', 'io.syncpoint.odin.operation', { content: 'abc' }])
+    assert.ok(key, 'should have a persistence key')
+    await queue.acknowledge(key)
+  })
+
+  it('should maintain FIFO order', async () => {
+    const queue = new FIFO(db)
+    await queue.enqueue(['sendMessageEvent', '!room:test', 'type', { id: 1 }])
+    await queue.enqueue(['sendMessageEvent', '!room:test', 'type', { id: 2 }])
+    await queue.enqueue(['sendMessageEvent', '!room:test', 'type', { id: 3 }])
+
+    const first = await queue.dequeue()
+    const second = await queue.dequeue()
+    const third = await queue.dequeue()
+
+    assert.deepStrictEqual(first.command[3].id, 1)
+    assert.deepStrictEqual(second.command[3].id, 2)
+    assert.deepStrictEqual(third.command[3].id, 3)
+  })
+
+  it('should persist commands across instances', async () => {
+    // Enqueue with first instance
+    const queue1 = new FIFO(db)
+    await queue1.enqueue(['sendMessageEvent', '!room:test', 'type', { data: 'persisted' }])
+
+    // Create second instance on same DB (simulates restart)
+    const queue2 = new FIFO(db)
+    const { command, key } = await queue2.dequeue()
+
+    assert.deepStrictEqual(command, ['sendMessageEvent', '!room:test', 'type', { data: 'persisted' }])
+    assert.ok(key)
+  })
+
+  it('should remove entry from DB after acknowledge', async () => {
+    const queue = new FIFO(db)
+    await queue.enqueue(['sendMessageEvent', '!room:test', 'type', { data: 'temp' }])
+
+    const { key } = await queue.dequeue()
+    await queue.acknowledge(key)
+
+    // New instance should have empty queue
+    const queue2 = new FIFO(db)
+    assert.ok(queue2.isEmpty() || queue2.length === 0)
+  })
+
+  it('should keep entry in DB if not acknowledged (crash simulation)', async () => {
+    const queue1 = new FIFO(db)
+    await queue1.enqueue(['sendMessageEvent', '!room:test', 'type', { data: 'will-crash' }])
+
+    // Dequeue but do NOT acknowledge (simulates crash)
+    await queue1.dequeue()
+
+    // New instance should still have the entry
+    const queue2 = new FIFO(db)
+    const { command } = await queue2.dequeue()
+    assert.deepStrictEqual(command[3].data, 'will-crash')
+  })
+
+  it('should handle callback functions in-memory only (no key)', async () => {
+    const queue = new FIFO(db)
+    const callback = async () => {}
+    await queue.enqueue([callback])
+
+    const { command, key } = await queue.dequeue()
+    assert.strictEqual(typeof command[0], 'function')
+    assert.strictEqual(key, null, 'callbacks should not have a persistence key')
+  })
+
+  it('should requeue a failed command at the front', async () => {
+    const queue = new FIFO(db)
+    await queue.enqueue(['sendMessageEvent', '!room:test', 'type', { id: 1 }])
+    await queue.enqueue(['sendMessageEvent', '!room:test', 'type', { id: 2 }])
+
+    const first = await queue.dequeue()
+    // Simulate failure — requeue first entry
+    queue.requeue(first.command, first.key)
+
+    const retry = await queue.dequeue()
+    assert.deepStrictEqual(retry.command[3].id, 1, 'requeued entry should come first')
+  })
+
+  it('should report correct length', async () => {
+    const queue = new FIFO(db)
+    assert.strictEqual(queue.length, 0)
+
+    await queue.enqueue(['sendMessageEvent', '!room:test', 'type', {}])
+    assert.strictEqual(queue.length, 1)
+
+    await queue.enqueue(['sendMessageEvent', '!room:test', 'type', {}])
+    assert.strictEqual(queue.length, 2)
+
+    await queue.dequeue()
+    assert.strictEqual(queue.length, 1)
+  })
+
+  it('should restore multiple commands in correct order after restart', async () => {
+    const queue1 = new FIFO(db)
+    await queue1.enqueue(['sendMessageEvent', '!room:test', 'type', { order: 'A' }])
+    await queue1.enqueue(['sendMessageEvent', '!room:test', 'type', { order: 'B' }])
+    await queue1.enqueue(['sendMessageEvent', '!room:test', 'type', { order: 'C' }])
+
+    // Simulate restart
+    const queue2 = new FIFO(db)
+    const a = await queue2.dequeue()
+    const b = await queue2.dequeue()
+    const c = await queue2.dequeue()
+
+    assert.strictEqual(a.command[3].order, 'A')
+    assert.strictEqual(b.command[3].order, 'B')
+    assert.strictEqual(c.command[3].order, 'C')
+  })
+
+  it('should continue counter after restart to avoid key collisions', async () => {
+    const queue1 = new FIFO(db)
+    await queue1.enqueue(['sendMessageEvent', '!room:test', 'type', { id: 1 }])
+    const { key: key1 } = await queue1.dequeue()
+    await queue1.acknowledge(key1)
+
+    // Simulate restart, add new entry
+    const queue2 = new FIFO(db)
+    await queue2._ready
+    await queue2.enqueue(['sendMessageEvent', '!room:test', 'type', { id: 2 }])
+    const { key: key2 } = await queue2.dequeue()
+
+    assert.notStrictEqual(key1, key2, 'keys should be unique across restarts')
+  })
+})

--- a/test/queue.test.mjs
+++ b/test/queue.test.mjs
@@ -1,13 +1,10 @@
 import assert from 'node:assert/strict'
 import { describe, it, beforeEach } from 'mocha'
-import memdown from 'memdown'
-import levelup from 'levelup'
-import subleveldown from 'subleveldown'
+import { MemoryLevel } from 'memory-level'
 import { FIFO } from '../src/queue.mjs'
 
 const createDB = () => {
-  const db = levelup(memdown())
-  return subleveldown(db, 'command-queue', { valueEncoding: 'json' })
+  return new MemoryLevel({ valueEncoding: 'json' })
 }
 
 describe('Persistent FIFO Queue', function () {


### PR DESCRIPTION
## Summary

Replace the in-memory command queue with a LevelDB-backed persistent queue. Commands now survive ODIN restarts and Electron reloads.

## Problem

When ODIN restarts or reloads (e.g. during development, after a crash, or network issues), all pending commands in the FIFO queue are lost. This means user operations that were already made locally but not yet delivered to the Matrix server are silently dropped.

## Solution

The FIFO queue now persists serializable commands to a LevelDB instance (injected via constructor). Non-serializable entries (callback functions for key sharing) remain in-memory only, as they are covered by existing safety nets (the WASM SDK's `outgoingRequests()` and the stream-based key re-sharing on member join).

### Design

- **DB injection**: The queue receives a `levelup`-compatible database instance (e.g. a `subleveldown` of ODIN's existing LevelDB). No own DB is opened.
- **Monotonic counter keys**: `cmd:0000000000000001`, `cmd:0000000000000002`, etc. — guarantees FIFO order and avoids timestamp-based collision issues.
- **Counter persistence**: The counter is persisted separately (`_counter` key) and atomically batch-written with each command, so it survives acknowledge cycles.
- **Acknowledge pattern**: Entries are removed from DB only after successful HTTP delivery (`acknowledge(key)`). If ODIN crashes between dequeue and acknowledge, the entry remains in DB and is retried on restart.
- **Idempotency**: Matrix `sendMessageEvent` with `txnId` is already idempotent, so duplicate sends after crash recovery are safe.

### Integration in ODIN

```javascript
import subleveldown from 'subleveldown'

const commandQueueDB = subleveldown(odinDB, 'command-queue', { valueEncoding: 'json' })

const client = MatrixClient({
  home_server_url: '...',
  user_id: '...',
  password: '...',
  db: commandQueueDB
})
```

## Changes

- **`queue.mjs`** — Rewritten: LevelDB-backed FIFO with `enqueue()`, `dequeue()`, `acknowledge()`, `requeue()`
- **`command-api.mjs`** — Takes `db` as third constructor parameter. `run()` calls `acknowledge(key)` after successful send.
- **`index.mjs`** — Passes `loginData.db` to CommandAPI

## Breaking Changes

- `CommandAPI` constructor now requires a third `db` parameter (levelup-compatible instance)
- `FIFO` constructor now requires a `db` parameter

## Compatibility

Uses `levelup`/`subleveldown` API (`createReadStream`, callback-based `batch`/`del`) matching ODIN's current LevelDB stack. Migration to `abstract-level` is tracked in #7.

## Test Results

```
npm test → 50 passing (10 new queue tests)
```

New test coverage:
- Enqueue/dequeue round-trip
- FIFO ordering
- Persistence across instances (restart simulation)
- Acknowledge removes from DB
- Crash recovery (dequeue without acknowledge)
- Callback functions stay in-memory (no key)
- Requeue at front
- Length tracking
- Multi-entry restore ordering
- Counter continuity across restarts
