### PR TITLE
Restart sync on joinLayer for immediate room detection

### DIFF
--- a/src/http-api.mjs
+++ b/src/http-api.mjs
@@ -370,7 +370,7 @@ HttpAPI.prototype.sendToDevice = async function (eventType, txnId = randomUUID()
   }).json()
 }
 
-HttpAPI.prototype.sync = async function (since, filter, timeout = POLL_TIMEOUT) {
+HttpAPI.prototype.sync = async function (since, filter, timeout = POLL_TIMEOUT, signal) {
   const buildSearchParams = (since, filter, timeout) => {
     const params = {
       timeout
@@ -380,9 +380,9 @@ HttpAPI.prototype.sync = async function (since, filter, timeout = POLL_TIMEOUT) 
     if (f) params.filter = f
     return params
   }
-  return this.client.get('v3/sync', {
-    searchParams: buildSearchParams(since, filter, timeout)
-  }).json()
+  const options = { searchParams: buildSearchParams(since, filter, timeout) }
+  if (signal) options.signal = signal
+  return this.client.get('v3/sync', options).json()
 }
 
 /**

--- a/src/project.mjs
+++ b/src/project.mjs
@@ -145,10 +145,10 @@ Project.prototype.joinLayer = async function (layerId) {
   this.idMapping.remember(upstreamId, upstreamId)
   this.pendingContent.add(upstreamId)
 
-  // 2. Restart the sync long-poll so it picks up the updated rooms filter
-  //    immediately. The restarted poll will be waiting when the join event
-  //    arrives on the server.
-  this.timelineAPI.restartSync()
+  // 2. Restart the sync long-poll and WAIT until the new iteration has
+  //    applied the updated rooms filter. This ensures the sync request
+  //    that includes the new room is already in flight before we join.
+  await this.timelineAPI.restartSync()
 
   // 3. NOW perform the actual join — the sync poll already includes this room.
   await this.structureAPI.join(upstreamId)

--- a/src/project.mjs
+++ b/src/project.mjs
@@ -38,7 +38,8 @@ const Project = function ({ structureAPI, timelineAPI, commandAPI, memberCache, 
 
   // Rooms waiting for their first sync cycle before content is fetched.
   // joinLayer() adds entries, start() processes them when the room appears in sync.
-  // Maps roomId → { retries: number } to track federation backfill retries.
+  // Maps roomId → { retries: number, prevBatch: string|null } to track
+  // federation backfill retries and the pagination token.
   this.pendingContent = new Map()
 }
 
@@ -144,7 +145,7 @@ Project.prototype.joinLayer = async function (layerId) {
   // 1. Add the upstream (Matrix) room ID to the filter BEFORE joining
   //    so the next sync poll includes it.
   this.idMapping.remember(upstreamId, upstreamId)
-  this.pendingContent.set(upstreamId, { retries: 0 })
+  this.pendingContent.set(upstreamId, { retries: 0, prevBatch: null })
 
   // 2. Restart the sync long-poll and WAIT until the new iteration has
   //    applied the updated rooms filter. This ensures the sync request
@@ -230,7 +231,7 @@ Project.prototype.setDefaultRole = async function (layerId, role) {
 
 Project.prototype.roles = Object.fromEntries(Object.keys(power.ROLES.LAYER).map(k =>[k, k]))
 
-Project.prototype.content = async function (layerId) {
+Project.prototype.content = async function (layerId, from) {
   const filter = {
       lazy_load_members: true, // improve performance
       limit: 1000,
@@ -240,7 +241,7 @@ Project.prototype.content = async function (layerId) {
     }
 
   const upstreamId = this.idMapping.get(layerId)
-  const content = await this.timelineAPI.content(upstreamId, filter)
+  const content = await this.timelineAPI.content(upstreamId, filter, from)
   const operations = content.events
     .map(event =>
       JSON.parse(Base64.decode(event.content.content))
@@ -355,11 +356,18 @@ Project.prototype.start = async function (streamToken, handler = {}) {
     for (const [roomId, state] of this.pendingContent) {
       if (!chunk.events[roomId] && !chunk.stateEvents?.[roomId]) continue
 
+      // Capture the prev_batch token from this sync response if available.
+      // On federation joins the first sync may have limited:true with a
+      // prev_batch that is the correct starting point for backward pagination.
+      if (chunk.prevBatches?.[roomId]) {
+        state.prevBatch = chunk.prevBatches[roomId]
+      }
+
       const log = getLogger()
-      log.info(`Sync-gated content fetch for room ${roomId} (attempt ${state.retries + 1})`)
+      log.info(`Sync-gated content fetch for room ${roomId} (attempt ${state.retries + 1}, prevBatch: ${state.prevBatch || 'none'})`)
 
       const layerId = this.idMapping.get(roomId)
-      const operations = await this.content(layerId)
+      const operations = await this.content(layerId, state.prevBatch)
 
       if (operations.length > 0) {
         this.pendingContent.delete(roomId)

--- a/src/project.mjs
+++ b/src/project.mjs
@@ -38,7 +38,8 @@ const Project = function ({ structureAPI, timelineAPI, commandAPI, memberCache, 
 
   // Rooms waiting for their first sync cycle before content is fetched.
   // joinLayer() adds entries, start() processes them when the room appears in sync.
-  this.pendingContent = new Set()
+  // Maps roomId → { retries: number } to track federation backfill retries.
+  this.pendingContent = new Map()
 }
 
 /**
@@ -143,7 +144,7 @@ Project.prototype.joinLayer = async function (layerId) {
   // 1. Add the upstream (Matrix) room ID to the filter BEFORE joining
   //    so the next sync poll includes it.
   this.idMapping.remember(upstreamId, upstreamId)
-  this.pendingContent.add(upstreamId)
+  this.pendingContent.set(upstreamId, { retries: 0 })
 
   // 2. Restart the sync long-poll and WAIT until the new iteration has
   //    applied the updated rooms filter. This ensures the sync request
@@ -346,20 +347,32 @@ Project.prototype.start = async function (streamToken, handler = {}) {
     // Check both timeline events and state events — the room may appear in sync
     // with only state (e.g. the join event) but no timeline events if the
     // server-side filter excludes the current user's events via not_senders.
-    for (const roomId of this.pendingContent) {
+    //
+    // Federation backfill retry: when /messages returns empty (the remote
+    // server hasn't backfilled yet), keep the room pending and retry on
+    // subsequent sync cycles up to MAX_CONTENT_RETRIES times.
+    const MAX_CONTENT_RETRIES = 10
+    for (const [roomId, state] of this.pendingContent) {
       if (!chunk.events[roomId] && !chunk.stateEvents?.[roomId]) continue
 
-      this.pendingContent.delete(roomId)
       const log = getLogger()
-      log.info(`Sync-gated content fetch for room ${roomId}`)
+      log.info(`Sync-gated content fetch for room ${roomId} (attempt ${state.retries + 1})`)
 
       const layerId = this.idMapping.get(roomId)
       const operations = await this.content(layerId)
 
-      log.info(`Sync-gated content: ${operations.length} operations for room ${roomId}`)
-
       if (operations.length > 0) {
+        this.pendingContent.delete(roomId)
+        log.info(`Sync-gated content: ${operations.length} operations for room ${roomId}`)
         await streamHandler.received({ id: layerId, operations })
+      } else {
+        state.retries++
+        if (state.retries >= MAX_CONTENT_RETRIES) {
+          this.pendingContent.delete(roomId)
+          log.warn(`Sync-gated content: giving up on room ${roomId} after ${MAX_CONTENT_RETRIES} retries (empty content)`)
+        } else {
+          log.info(`Sync-gated content: empty response for room ${roomId}, will retry (${state.retries}/${MAX_CONTENT_RETRIES})`)
+        }
       }
     }
 

--- a/src/project.mjs
+++ b/src/project.mjs
@@ -20,7 +20,7 @@ const MAX_MESSAGE_SIZE = 56 * 1024
  * @param {Object} apis
  * @property {StructureAPI} structureAPI
  */
-const CONTENT_RETRY_INTERVAL_MS = 5000
+const CONTENT_RETRY_INTERVAL_MS = 10000
 
 const Project = function ({ structureAPI, timelineAPI, commandAPI, memberCache, crypto = {}, contentRetryIntervalMs } = {}) {
   this.contentRetryIntervalMs = contentRetryIntervalMs ?? CONTENT_RETRY_INTERVAL_MS
@@ -355,7 +355,7 @@ Project.prototype.start = async function (streamToken, handler = {}) {
     // Federation backfill retry: when /messages returns empty (the remote
     // server hasn't backfilled yet), keep the room pending and retry on
     // subsequent sync cycles up to MAX_CONTENT_RETRIES times.
-    const MAX_CONTENT_RETRIES = 10
+    const MAX_CONTENT_RETRIES = 20
     for (const [roomId, state] of this.pendingContent) {
 
       // On the first attempt, wait for the room to appear in sync.

--- a/src/project.mjs
+++ b/src/project.mjs
@@ -20,7 +20,10 @@ const MAX_MESSAGE_SIZE = 56 * 1024
  * @param {Object} apis
  * @property {StructureAPI} structureAPI
  */
-const Project = function ({ structureAPI, timelineAPI, commandAPI, memberCache, crypto = {} }) {
+const CONTENT_RETRY_INTERVAL_MS = 5000
+
+const Project = function ({ structureAPI, timelineAPI, commandAPI, memberCache, crypto = {}, contentRetryIntervalMs } = {}) {
+  this.contentRetryIntervalMs = contentRetryIntervalMs ?? CONTENT_RETRY_INTERVAL_MS
   this.structureAPI = structureAPI
   this.timelineAPI = timelineAPI
   this.commandAPI = commandAPI
@@ -145,7 +148,7 @@ Project.prototype.joinLayer = async function (layerId) {
   // 1. Add the upstream (Matrix) room ID to the filter BEFORE joining
   //    so the next sync poll includes it.
   this.idMapping.remember(upstreamId, upstreamId)
-  this.pendingContent.set(upstreamId, { retries: 0, prevBatch: null })
+  this.pendingContent.set(upstreamId, { retries: 0, prevBatch: null, seenInSync: false, lastAttempt: null })
 
   // 2. Restart the sync long-poll and WAIT until the new iteration has
   //    applied the updated rooms filter. This ensures the sync request
@@ -354,7 +357,17 @@ Project.prototype.start = async function (streamToken, handler = {}) {
     // subsequent sync cycles up to MAX_CONTENT_RETRIES times.
     const MAX_CONTENT_RETRIES = 10
     for (const [roomId, state] of this.pendingContent) {
-      if (!chunk.events[roomId] && !chunk.stateEvents?.[roomId]) continue
+
+      // On the first attempt, wait for the room to appear in sync.
+      // On retries, proceed on every sync cycle (the room won't appear
+      // again — no new events — but we need to retry for key delivery).
+      if (!state.seenInSync) {
+        if (!chunk.events[roomId] && !chunk.stateEvents?.[roomId]) continue
+        state.seenInSync = true
+      } else {
+        // Throttle retries: skip if less than contentRetryIntervalMs since last attempt
+        if (state.lastAttempt && (Date.now() - state.lastAttempt) < this.contentRetryIntervalMs) continue
+      }
 
       // Capture the prev_batch token from this sync response if available.
       // On federation joins the first sync may have limited:true with a
@@ -366,6 +379,7 @@ Project.prototype.start = async function (streamToken, handler = {}) {
       const log = getLogger()
       log.info(`Sync-gated content fetch for room ${roomId} (attempt ${state.retries + 1}, prevBatch: ${state.prevBatch || 'none'})`)
 
+      state.lastAttempt = Date.now()
       const layerId = this.idMapping.get(roomId)
       const operations = await this.content(layerId, state.prevBatch)
 

--- a/src/project.mjs
+++ b/src/project.mjs
@@ -140,18 +140,29 @@ Project.prototype.joinLayer = async function (layerId) {
 
   const upstreamId = this.idMapping.get(layerId) || (Base64.isValid(layerId) ? Base64.decode(layerId) : layerId)
 
+  // 1. Add the upstream (Matrix) room ID to the filter BEFORE joining
+  //    so the next sync poll includes it.
+  this.idMapping.remember(upstreamId, upstreamId)
+  this.pendingContent.add(upstreamId)
+
+  // 2. Restart the sync long-poll so it picks up the updated rooms filter
+  //    immediately. The restarted poll will be waiting when the join event
+  //    arrives on the server.
+  this.timelineAPI.restartSync()
+
+  // 3. NOW perform the actual join — the sync poll already includes this room.
   await this.structureAPI.join(upstreamId)
   const room = await this.structureAPI.getLayer(upstreamId)
+
+  // 4. Replace the temporary self-mapping with the real ODIN↔Matrix mapping.
+  //    room.room_id === upstreamId, so pendingContent stays valid.
+  this.idMapping.forget(upstreamId)
   this.idMapping.remember(room.id, room.room_id)
 
   // Register encryption if applicable (needed before content can be decrypted)
   if (this.crypto.isEnabled && room.encryption) {
     await this.crypto.registerRoom(room.room_id)
   }
-
-  // Mark for sync-gated content fetch: content will be loaded once the room
-  // appears in a sync response, not immediately after join.
-  this.pendingContent.add(room.room_id)
 
   const layer = {...room}
   layer.role = {

--- a/src/timeline-api.mjs
+++ b/src/timeline-api.mjs
@@ -97,7 +97,7 @@ TimelineAPI.prototype.content = async function (roomId, filter, _from) {
 }
 
 
-TimelineAPI.prototype.syncTimeline = async function(since, filter, timeout = 0) {
+TimelineAPI.prototype.syncTimeline = async function(since, filter, timeout = 0, signal) {
   /*
     We want the complete timeline for all rooms that we have already joined. Thus we get the most recent
     events and then iterate over partial results until we filled the gap. The order of the events shall be
@@ -117,7 +117,7 @@ TimelineAPI.prototype.syncTimeline = async function(since, filter, timeout = 0) 
   // for catching up
   const jobs = {}
 
-  const syncResult = await this.httpApi.sync(since, effectiveFilter, timeout)
+  const syncResult = await this.httpApi.sync(since, effectiveFilter, timeout, signal)
 
   // Feed crypto state from sync response
   if (this.onSyncResponse) {
@@ -263,26 +263,55 @@ TimelineAPI.prototype.catchUp = async function (roomId, lastKnownStreamToken, cu
 }
 
 
+/**
+ * Abort the current long-poll sync request so that the stream restarts
+ * immediately with an updated filter (e.g. after joinLayer added a room
+ * to idMapping). The stream loop catches the abort and re-enters the
+ * next iteration without incrementing the retry counter.
+ */
+TimelineAPI.prototype.restartSync = function () {
+  if (this._syncAbort) {
+    this._syncAbort.abort()
+    this._syncAbort = null
+  }
+}
+
 TimelineAPI.prototype.stream = async function* (since, filterProvider, signal = (new AbortController()).signal) {
-
-
 
   let streamToken = since
   let retryCounter = 0
 
   while (!signal.aborted) {
+    // Each iteration gets its own AbortController so that restartSync()
+    // can cancel the current long-poll without stopping the stream.
+    const iterationAbort = new AbortController()
+    this._syncAbort = iterationAbort
+
+    // Forward the outer lifecycle signal: if the stream is stopped,
+    // also abort the current request.
+    const onOuterAbort = () => iterationAbort.abort()
+    signal.addEventListener('abort', onOuterAbort, { once: true })
+
     try {
       await chill(retryCounter)
       const filter = filterProvider ? filterProvider() : undefined
-      const syncResult = await this.syncTimeline(streamToken, filter, DEFAULT_POLL_TIMEOUT, signal)
+      const syncResult = await this.syncTimeline(streamToken, filter, DEFAULT_POLL_TIMEOUT, iterationAbort.signal)
       retryCounter = 0
       if (streamToken !== syncResult.next_batch) {
         streamToken = syncResult.next_batch
         yield syncResult
       }
     } catch (error) {
+      if (iterationAbort.signal.aborted && !signal.aborted) {
+        // restartSync() was called — not an error, just restart immediately
+        getLogger().debug('Sync restarted (filter update)')
+        continue
+      }
       retryCounter++
       yield new Error(error)
+    } finally {
+      signal.removeEventListener('abort', onOuterAbort)
+      this._syncAbort = null
     }
   }
 }

--- a/src/timeline-api.mjs
+++ b/src/timeline-api.mjs
@@ -64,7 +64,7 @@ TimelineAPI.prototype.credentials = function () {
   return this.httpApi.credentials
 }
 
-TimelineAPI.prototype.content = async function (roomId, filter, _from) {
+TimelineAPI.prototype.content = async function (roomId, filter, from) {
   getLogger().debug('Timeline content filter:', JSON.stringify(filter))
 
   // Augment the filter for crypto: add m.room.encrypted to types
@@ -75,7 +75,12 @@ TimelineAPI.prototype.content = async function (roomId, filter, _from) {
     originalTypes = filter.types
   }
 
-  const result = await this.catchUp(roomId, null, null, 'f', effectiveFilter)
+  // When a pagination token is provided (e.g. prev_batch from sync), paginate
+  // backwards from that point. This is essential for federation scenarios where
+  // forward pagination from the start returns empty results because the remote
+  // server hasn't backfilled yet, but backward pagination from prev_batch works.
+  const dir = from ? 'b' : 'f'
+  const result = await this.catchUp(roomId, null, from || null, dir, effectiveFilter)
 
   // Decrypt + post-filter
   if (this.decryptEvent && result.events) {
@@ -130,6 +135,7 @@ TimelineAPI.prototype.syncTimeline = async function(since, filter, timeout = 0, 
   }
 
   const stateEvents = {}
+  const prevBatches = {}
 
   for (const [roomId, content] of Object.entries(syncResult.rooms?.join || {})) {
     // Collect state events (membership changes, power levels, etc.)
@@ -140,6 +146,14 @@ TimelineAPI.prototype.syncTimeline = async function(since, filter, timeout = 0, 
     const timelineState = (content.timeline?.events || []).filter(e => 'state_key' in e)
     if (timelineState.length) {
       stateEvents[roomId] = [...(stateEvents[roomId] || []), ...timelineState]
+    }
+
+    // Preserve prev_batch for all rooms with limited timeline (even if events are empty).
+    // This is needed for federation backfill: the room may appear in sync with
+    // limited:true but empty events — the prev_batch is still the correct
+    // pagination token to fetch historical content.
+    if (content.timeline?.limited && content.timeline?.prev_batch) {
+      prevBatches[roomId] = content.timeline.prev_batch
     }
 
     if (!content.timeline?.events?.length) continue
@@ -195,7 +209,8 @@ TimelineAPI.prototype.syncTimeline = async function(since, filter, timeout = 0, 
     since,
     next_batch: syncResult.next_batch,
     events,
-    stateEvents
+    stateEvents,
+    prevBatches
   }
 }
 

--- a/src/timeline-api.mjs
+++ b/src/timeline-api.mjs
@@ -270,10 +270,16 @@ TimelineAPI.prototype.catchUp = async function (roomId, lastKnownStreamToken, cu
  * next iteration without incrementing the retry counter.
  */
 TimelineAPI.prototype.restartSync = function () {
+  const promise = new Promise(resolve => {
+    this._onSyncRestarted = resolve
+  })
+
   if (this._syncAbort) {
     this._syncAbort.abort()
     this._syncAbort = null
   }
+
+  return promise
 }
 
 TimelineAPI.prototype.stream = async function* (since, filterProvider, signal = (new AbortController()).signal) {
@@ -295,6 +301,13 @@ TimelineAPI.prototype.stream = async function* (since, filterProvider, signal = 
     try {
       await chill(retryCounter)
       const filter = filterProvider ? filterProvider() : undefined
+
+      // Signal that the restarted iteration has applied the updated filter.
+      if (this._onSyncRestarted) {
+        this._onSyncRestarted()
+        this._onSyncRestarted = null
+      }
+
       const syncResult = await this.syncTimeline(streamToken, filter, DEFAULT_POLL_TIMEOUT, iterationAbort.signal)
       retryCounter = 0
       if (streamToken !== syncResult.next_batch) {

--- a/test-e2e/project-join-content.test.mjs
+++ b/test-e2e/project-join-content.test.mjs
@@ -174,4 +174,91 @@ describe('Project Join Content (E2E)', function () {
         `Operation at index ${i} out of order`)
     }
   })
+
+  it('sync-gated received() delivers content after joinLayer() restarts sync', async function () {
+    // Fresh users for a clean sync state
+    const alice2Creds = await registerUser(`alice2_pjc_${suffix}`)
+    const bob2Creds = await registerUser(`bob2_pjc_${suffix}`)
+    const alice2Client = MatrixClient({ ...alice2Creds, db: createDB() })
+    const bob2Client = MatrixClient({ ...bob2Creds, db: createDB() })
+
+    const projectId2 = `project2-${suffix}`
+    const layerId2 = `layer2-${suffix}`
+
+    // Alice: create project, layer, post content, invite Bob
+    const alice2ProjectList = await alice2Client.projectList(alice2Creds)
+    const shared = await alice2ProjectList.share(projectId2, 'Sync-Gate Test', 'E2E')
+
+    const alice2Project = await alice2Client.project(alice2Creds)
+    await alice2Project.hydrate({ id: projectId2, upstreamId: shared.upstreamId })
+    await alice2Project.shareLayer(layerId2, 'Test Layer', '')
+    await alice2Project.post(layerId2, testOps)
+    await waitForQueueDrain(alice2Project)
+
+    await alice2ProjectList.invite(projectId2, bob2Creds.user_id)
+
+    // Bob: receive invitation
+    const bob2ProjectList = await bob2Client.projectList(bob2Creds)
+
+    const invitation = await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('No invite received')), 15000)
+      bob2ProjectList.start(null, {
+        error: async (err) => { clearTimeout(timer); reject(err) },
+        invited: async (project) => {
+          clearTimeout(timer)
+          await bob2ProjectList.stop()
+          resolve(project)
+        }
+      })
+    })
+
+    // Bob: join project, hydrate
+    await bob2ProjectList.join(invitation.id)
+    const bob2Project = await bob2Client.project(bob2Creds)
+    const structure = await bob2Project.hydrate({
+      id: invitation.id,
+      upstreamId: bob2ProjectList.wellKnown.get(invitation.id)
+    })
+    assert.ok(structure.invitations.length > 0)
+
+    // Bob: start project stream FIRST, then join layer
+    // joinLayer() should restart the sync so the room appears immediately
+    const receivedOps = []
+    let receivedResolve
+    const receivedPromise = new Promise(resolve => { receivedResolve = resolve })
+    const receivedTimeout = setTimeout(() => receivedResolve(), 15000)
+
+    bob2Project.start(undefined, {
+      received: async ({ id, operations }) => {
+        receivedOps.push(...operations)
+        if (receivedOps.length >= testOps.length) {
+          clearTimeout(receivedTimeout)
+          receivedResolve()
+        }
+      },
+      error: async (err) => console.error('Stream error:', err)
+    })
+
+    // Give stream a moment to start its first long-poll
+    await new Promise(resolve => setTimeout(resolve, 1000))
+
+    // Bob joins the layer — this should restart the sync
+    const inv = structure.invitations[0]
+    await bob2Project.joinLayer(inv.id)
+
+    // Wait for content via received()
+    await receivedPromise
+    await bob2Project.stop()
+    await alice2Project.commandAPI.stop()
+
+    console.log(`  Sync-gated received() delivered ${receivedOps.length} operations`)
+
+    assert.equal(receivedOps.length, testOps.length,
+      `Expected ${testOps.length} operations via received(), got ${receivedOps.length}`)
+
+    for (let i = 0; i < testOps.length; i++) {
+      assert.deepStrictEqual(receivedOps[i], testOps[i],
+        `Operation at index ${i} out of order`)
+    }
+  })
 })

--- a/test/sync-gated-content.test.mjs
+++ b/test/sync-gated-content.test.mjs
@@ -205,7 +205,7 @@ describe('Sync-Gated Content after Join', function () {
       project.idMapping.remember(layerId, roomId)
 
       // Simulate: room was just joined
-      project.pendingContent.set(roomId, { retries: 0 })
+      project.pendingContent.set(roomId, { retries: 0, prevBatch: null })
 
       // Run start with a handler that captures received operations
       await project.start('batch_1', {
@@ -253,7 +253,7 @@ describe('Sync-Gated Content after Join', function () {
       })
 
       project.idMapping.remember('layer-1', roomId)
-      project.pendingContent.set(roomId, { retries: 0 })
+      project.pendingContent.set(roomId, { retries: 0, prevBatch: null })
 
       await project.start('batch_1', {
         streamToken: async () => {}
@@ -288,7 +288,7 @@ describe('Sync-Gated Content after Join', function () {
       })
 
       project.idMapping.remember('layer-1', roomId)
-      project.pendingContent.set(roomId, { retries: 0 })
+      project.pendingContent.set(roomId, { retries: 0, prevBatch: null })
 
       await project.start('batch_1', {
         streamToken: async () => {},
@@ -323,7 +323,7 @@ describe('Sync-Gated Content after Join', function () {
       })
 
       project.idMapping.remember('layer-1', roomId)
-      project.pendingContent.set(roomId, { retries: 0 })
+      project.pendingContent.set(roomId, { retries: 0, prevBatch: null })
 
       await project.start('batch_1', {
         streamToken: async () => {}
@@ -380,8 +380,8 @@ describe('Sync-Gated Content after Join', function () {
 
       project.idMapping.remember('layer-1', room1)
       project.idMapping.remember('layer-2', room2)
-      project.pendingContent.set(room1, { retries: 0 })
-      project.pendingContent.set(room2, { retries: 0 })
+      project.pendingContent.set(room1, { retries: 0, prevBatch: null })
+      project.pendingContent.set(room2, { retries: 0, prevBatch: null })
 
       await project.start('batch_1', {
         streamToken: async () => {},
@@ -400,8 +400,10 @@ describe('Sync-Gated Content after Join', function () {
 
     it('should retry content fetch on empty response (federation backfill)', async () => {
       const roomId = '!federated:remote'
+      const prevBatchToken = 't123_prev_batch'
       const ops = [{ type: 'put', key: 'f:1', value: {} }]
       const receivedOps = []
+      const contentFromTokens = []
 
       let contentCallIndex = 0
       // First two calls return empty (backfill not ready), third returns data
@@ -413,15 +415,16 @@ describe('Sync-Gated Content after Join', function () {
 
       const timelineAPI = createTimelineAPI({
         syncChunks: [
-          // Three sync cycles, each containing the room
-          { next_batch: 'b2', events: { [roomId]: [{ type: 'm.room.member', state_key: '@a:test', content: { membership: 'join' } }] }, stateEvents: {} },
+          // First sync: room appears with prev_batch token (federation backfill scenario)
+          { next_batch: 'b2', events: { [roomId]: [{ type: 'm.room.member', state_key: '@a:test', content: { membership: 'join' } }] }, stateEvents: {}, prevBatches: { [roomId]: prevBatchToken } },
           { next_batch: 'b3', events: { [roomId]: [{ type: 'm.room.member', state_key: '@a:test', content: { membership: 'join' } }] }, stateEvents: {} },
           { next_batch: 'b4', events: { [roomId]: [{ type: 'm.room.member', state_key: '@a:test', content: { membership: 'join' } }] }, stateEvents: {} }
         ]
       })
 
-      timelineAPI.content = async () => {
+      timelineAPI.content = async (rid, filter, from) => {
         timelineAPI._contentCallCount++
+        contentFromTokens.push(from)
         return contentResults[contentCallIndex++]
       }
 
@@ -432,7 +435,7 @@ describe('Sync-Gated Content after Join', function () {
       })
 
       project.idMapping.remember('layer-1', roomId)
-      project.pendingContent.set(roomId, { retries: 0 })
+      project.pendingContent.set(roomId, { retries: 0, prevBatch: null })
 
       await project.start('b1', {
         streamToken: async () => {},
@@ -443,6 +446,9 @@ describe('Sync-Gated Content after Join', function () {
       assert.strictEqual(receivedOps.length, 1, 'received() should be called once with data')
       assert.deepStrictEqual(receivedOps[0].operations, ops)
       assert.ok(!project.pendingContent.has(roomId), 'Room should be removed after successful fetch')
+      // All three calls should use the prev_batch token for backward pagination
+      assert.deepStrictEqual(contentFromTokens, [prevBatchToken, prevBatchToken, prevBatchToken],
+        'content() should be called with prev_batch token')
     })
 
     it('should give up after MAX_CONTENT_RETRIES empty responses', async () => {
@@ -468,7 +474,7 @@ describe('Sync-Gated Content after Join', function () {
       })
 
       project.idMapping.remember('layer-1', roomId)
-      project.pendingContent.set(roomId, { retries: 0 })
+      project.pendingContent.set(roomId, { retries: 0, prevBatch: null })
 
       await project.start('b1', {
         streamToken: async () => {},

--- a/test/sync-gated-content.test.mjs
+++ b/test/sync-gated-content.test.mjs
@@ -50,7 +50,7 @@ const createTimelineAPI = ({ syncChunks = [], contentResult = { events: [] }, cr
       }
     },
 
-    restartSync: () => {},
+    restartSync: () => Promise.resolve(),
 
     // For assertions
     _contentCallCount: 0,
@@ -205,7 +205,7 @@ describe('Sync-Gated Content after Join', function () {
       project.idMapping.remember(layerId, roomId)
 
       // Simulate: room was just joined
-      project.pendingContent.add(roomId)
+      project.pendingContent.set(roomId, { retries: 0 })
 
       // Run start with a handler that captures received operations
       await project.start('batch_1', {
@@ -253,7 +253,7 @@ describe('Sync-Gated Content after Join', function () {
       })
 
       project.idMapping.remember('layer-1', roomId)
-      project.pendingContent.add(roomId)
+      project.pendingContent.set(roomId, { retries: 0 })
 
       await project.start('batch_1', {
         streamToken: async () => {}
@@ -288,7 +288,7 @@ describe('Sync-Gated Content after Join', function () {
       })
 
       project.idMapping.remember('layer-1', roomId)
-      project.pendingContent.add(roomId)
+      project.pendingContent.set(roomId, { retries: 0 })
 
       await project.start('batch_1', {
         streamToken: async () => {},
@@ -297,7 +297,9 @@ describe('Sync-Gated Content after Join', function () {
 
       assert.strictEqual(timelineAPI._contentCallCount, 1, 'content() should still be called')
       assert.strictEqual(receivedCalls.length, 0, 'received() should not be called for empty content')
-      assert.ok(!project.pendingContent.has(roomId), 'Room should be removed from pendingContent')
+      // With retry logic, room stays pending after first empty response
+      assert.ok(project.pendingContent.has(roomId), 'Room should stay in pendingContent for retry')
+      assert.strictEqual(project.pendingContent.get(roomId).retries, 1, 'Retry counter should be incremented')
     })
 
     it('should use content filter without not_senders', async () => {
@@ -321,7 +323,7 @@ describe('Sync-Gated Content after Join', function () {
       })
 
       project.idMapping.remember('layer-1', roomId)
-      project.pendingContent.add(roomId)
+      project.pendingContent.set(roomId, { retries: 0 })
 
       await project.start('batch_1', {
         streamToken: async () => {}
@@ -378,8 +380,8 @@ describe('Sync-Gated Content after Join', function () {
 
       project.idMapping.remember('layer-1', room1)
       project.idMapping.remember('layer-2', room2)
-      project.pendingContent.add(room1)
-      project.pendingContent.add(room2)
+      project.pendingContent.set(room1, { retries: 0 })
+      project.pendingContent.set(room2, { retries: 0 })
 
       await project.start('batch_1', {
         streamToken: async () => {},
@@ -394,6 +396,87 @@ describe('Sync-Gated Content after Join', function () {
       assert.strictEqual(receivedOps[1].id, 'layer-2')
       assert.ok(!project.pendingContent.has(room1))
       assert.ok(!project.pendingContent.has(room2))
+    })
+
+    it('should retry content fetch on empty response (federation backfill)', async () => {
+      const roomId = '!federated:remote'
+      const ops = [{ type: 'put', key: 'f:1', value: {} }]
+      const receivedOps = []
+
+      let contentCallIndex = 0
+      // First two calls return empty (backfill not ready), third returns data
+      const contentResults = [
+        { events: [] },
+        { events: [] },
+        { events: [{ type: ODINv2_MESSAGE_TYPE, content: { content: Base64.encodeURI(JSON.stringify(ops)) } }] }
+      ]
+
+      const timelineAPI = createTimelineAPI({
+        syncChunks: [
+          // Three sync cycles, each containing the room
+          { next_batch: 'b2', events: { [roomId]: [{ type: 'm.room.member', state_key: '@a:test', content: { membership: 'join' } }] }, stateEvents: {} },
+          { next_batch: 'b3', events: { [roomId]: [{ type: 'm.room.member', state_key: '@a:test', content: { membership: 'join' } }] }, stateEvents: {} },
+          { next_batch: 'b4', events: { [roomId]: [{ type: 'm.room.member', state_key: '@a:test', content: { membership: 'join' } }] }, stateEvents: {} }
+        ]
+      })
+
+      timelineAPI.content = async () => {
+        timelineAPI._contentCallCount++
+        return contentResults[contentCallIndex++]
+      }
+
+      const project = new Project({
+        structureAPI: createStructureAPI(),
+        timelineAPI,
+        commandAPI: createCommandAPI()
+      })
+
+      project.idMapping.remember('layer-1', roomId)
+      project.pendingContent.set(roomId, { retries: 0 })
+
+      await project.start('b1', {
+        streamToken: async () => {},
+        received: async ({ id, operations }) => { receivedOps.push({ id, operations }) }
+      })
+
+      assert.strictEqual(timelineAPI._contentCallCount, 3, 'content() should be called three times')
+      assert.strictEqual(receivedOps.length, 1, 'received() should be called once with data')
+      assert.deepStrictEqual(receivedOps[0].operations, ops)
+      assert.ok(!project.pendingContent.has(roomId), 'Room should be removed after successful fetch')
+    })
+
+    it('should give up after MAX_CONTENT_RETRIES empty responses', async () => {
+      const roomId = '!hopeless:remote'
+
+      // Generate 11 sync chunks all containing the room
+      const syncChunks = Array.from({ length: 11 }, (_, i) => ({
+        next_batch: `b${i + 2}`,
+        events: { [roomId]: [{ type: 'm.room.member', state_key: '@a:test', content: { membership: 'join' } }] },
+        stateEvents: {}
+      }))
+
+      const timelineAPI = createTimelineAPI({ syncChunks })
+      timelineAPI.content = async () => {
+        timelineAPI._contentCallCount++
+        return { events: [] }  // Always empty
+      }
+
+      const project = new Project({
+        structureAPI: createStructureAPI(),
+        timelineAPI,
+        commandAPI: createCommandAPI()
+      })
+
+      project.idMapping.remember('layer-1', roomId)
+      project.pendingContent.set(roomId, { retries: 0 })
+
+      await project.start('b1', {
+        streamToken: async () => {},
+        received: async () => { assert.fail('received() should not be called') }
+      })
+
+      assert.strictEqual(timelineAPI._contentCallCount, 10, 'Should stop after 10 retries')
+      assert.ok(!project.pendingContent.has(roomId), 'Room should be removed after giving up')
     })
   })
 })

--- a/test/sync-gated-content.test.mjs
+++ b/test/sync-gated-content.test.mjs
@@ -205,7 +205,7 @@ describe('Sync-Gated Content after Join', function () {
       project.idMapping.remember(layerId, roomId)
 
       // Simulate: room was just joined
-      project.pendingContent.set(roomId, { retries: 0, prevBatch: null })
+      project.pendingContent.set(roomId, { retries: 0, prevBatch: null, seenInSync: false, lastAttempt: null })
 
       // Run start with a handler that captures received operations
       await project.start('batch_1', {
@@ -249,11 +249,12 @@ describe('Sync-Gated Content after Join', function () {
       const project = new Project({
         structureAPI: createStructureAPI(),
         timelineAPI,
-        commandAPI: createCommandAPI()
+        commandAPI: createCommandAPI(),
+        contentRetryIntervalMs: 0
       })
 
       project.idMapping.remember('layer-1', roomId)
-      project.pendingContent.set(roomId, { retries: 0, prevBatch: null })
+      project.pendingContent.set(roomId, { retries: 0, prevBatch: null, seenInSync: false, lastAttempt: null })
 
       await project.start('batch_1', {
         streamToken: async () => {}
@@ -284,11 +285,12 @@ describe('Sync-Gated Content after Join', function () {
       const project = new Project({
         structureAPI: createStructureAPI(),
         timelineAPI,
-        commandAPI: createCommandAPI()
+        commandAPI: createCommandAPI(),
+        contentRetryIntervalMs: 0
       })
 
       project.idMapping.remember('layer-1', roomId)
-      project.pendingContent.set(roomId, { retries: 0, prevBatch: null })
+      project.pendingContent.set(roomId, { retries: 0, prevBatch: null, seenInSync: false, lastAttempt: null })
 
       await project.start('batch_1', {
         streamToken: async () => {},
@@ -319,11 +321,12 @@ describe('Sync-Gated Content after Join', function () {
       const project = new Project({
         structureAPI: createStructureAPI(),
         timelineAPI,
-        commandAPI: createCommandAPI()
+        commandAPI: createCommandAPI(),
+        contentRetryIntervalMs: 0
       })
 
       project.idMapping.remember('layer-1', roomId)
-      project.pendingContent.set(roomId, { retries: 0, prevBatch: null })
+      project.pendingContent.set(roomId, { retries: 0, prevBatch: null, seenInSync: false, lastAttempt: null })
 
       await project.start('batch_1', {
         streamToken: async () => {}
@@ -375,13 +378,14 @@ describe('Sync-Gated Content after Join', function () {
       const project = new Project({
         structureAPI: createStructureAPI(),
         timelineAPI,
-        commandAPI: createCommandAPI()
+        commandAPI: createCommandAPI(),
+        contentRetryIntervalMs: 0
       })
 
       project.idMapping.remember('layer-1', room1)
       project.idMapping.remember('layer-2', room2)
-      project.pendingContent.set(room1, { retries: 0, prevBatch: null })
-      project.pendingContent.set(room2, { retries: 0, prevBatch: null })
+      project.pendingContent.set(room1, { retries: 0, prevBatch: null, seenInSync: false, lastAttempt: null })
+      project.pendingContent.set(room2, { retries: 0, prevBatch: null, seenInSync: false, lastAttempt: null })
 
       await project.start('batch_1', {
         streamToken: async () => {},
@@ -431,11 +435,12 @@ describe('Sync-Gated Content after Join', function () {
       const project = new Project({
         structureAPI: createStructureAPI(),
         timelineAPI,
-        commandAPI: createCommandAPI()
+        commandAPI: createCommandAPI(),
+        contentRetryIntervalMs: 0
       })
 
       project.idMapping.remember('layer-1', roomId)
-      project.pendingContent.set(roomId, { retries: 0, prevBatch: null })
+      project.pendingContent.set(roomId, { retries: 0, prevBatch: null, seenInSync: false, lastAttempt: null })
 
       await project.start('b1', {
         streamToken: async () => {},
@@ -470,11 +475,12 @@ describe('Sync-Gated Content after Join', function () {
       const project = new Project({
         structureAPI: createStructureAPI(),
         timelineAPI,
-        commandAPI: createCommandAPI()
+        commandAPI: createCommandAPI(),
+        contentRetryIntervalMs: 0
       })
 
       project.idMapping.remember('layer-1', roomId)
-      project.pendingContent.set(roomId, { retries: 0, prevBatch: null })
+      project.pendingContent.set(roomId, { retries: 0, prevBatch: null, seenInSync: false, lastAttempt: null })
 
       await project.start('b1', {
         streamToken: async () => {},

--- a/test/sync-gated-content.test.mjs
+++ b/test/sync-gated-content.test.mjs
@@ -460,7 +460,7 @@ describe('Sync-Gated Content after Join', function () {
       const roomId = '!hopeless:remote'
 
       // Generate 11 sync chunks all containing the room
-      const syncChunks = Array.from({ length: 11 }, (_, i) => ({
+      const syncChunks = Array.from({ length: 21 }, (_, i) => ({
         next_batch: `b${i + 2}`,
         events: { [roomId]: [{ type: 'm.room.member', state_key: '@a:test', content: { membership: 'join' } }] },
         stateEvents: {}
@@ -487,7 +487,7 @@ describe('Sync-Gated Content after Join', function () {
         received: async () => { assert.fail('received() should not be called') }
       })
 
-      assert.strictEqual(timelineAPI._contentCallCount, 10, 'Should stop after 10 retries')
+      assert.strictEqual(timelineAPI._contentCallCount, 20, 'Should stop after 20 retries')
       assert.ok(!project.pendingContent.has(roomId), 'Room should be removed after giving up')
     })
   })

--- a/test/sync-gated-content.test.mjs
+++ b/test/sync-gated-content.test.mjs
@@ -50,6 +50,8 @@ const createTimelineAPI = ({ syncChunks = [], contentResult = { events: [] }, cr
       }
     },
 
+    restartSync: () => {},
+
     // For assertions
     _contentCallCount: 0,
     _lastContentFilter: null,


### PR DESCRIPTION
## Problem

After `joinLayer()`, the sync-gated content mechanism in `Project.start()` could not detect the room because the running long-poll's `rooms` filter didn't include it. The poll had to time out (30s) before the next one picked up the updated filter.

## Solution

Reorder `joinLayer()` to follow: **filter update → sync restart → join**

1. Add room to `idMapping` (temporary self-mapping) so it appears in the `rooms` filter
2. Call `restartSync()` to abort the current long-poll
3. Perform the actual `POST /join`
4. The restarted sync sees the join event → `stateEvents` check fires → `content()` loads operations → `received()` delivers them

## Implementation

- `httpApi.sync()`: Accept optional `AbortSignal`, pass to `ky`
- `TimelineAPI.restartSync()`: Abort the current iteration's `AbortController`
- `TimelineAPI.stream()`: Per-iteration `AbortController`, catch abort as restart (not error)
- `Project.joinLayer()`: Reordered as described above

## Tests

- 66 unit tests passing
- 2 E2E tests: immediate `content()` + sync-gated `received()` (1.5s)