### PR TITLE
fix: fall back to hierarchy data when space is missing from sync

### DIFF
--- a/src/structure-api.mjs
+++ b/src/structure-api.mjs
@@ -205,6 +205,20 @@ class StructureAPI {
                         }))
 
 
+    // Federation timing: the space room may not yet appear in the sync
+    // response right after joining. Fall back to hierarchy data which
+    // is always available.
+    if (!space) {
+      const hierarchySpace = hierarchy.rooms.find(room => room.room_id === globalId)
+      space = {
+        name: hierarchySpace?.name,
+        room_id: globalId,
+        topic: hierarchySpace?.topic,
+        powerlevel: undefined,
+        encryption: null
+      }
+    }
+
     const project = {
       name: space.name,
       powerlevel: space.powerlevel,


### PR DESCRIPTION
## Problem

After joining a federated project (e.g. matrix.org ↔ syncpoint.io), the space room may not yet appear in the sync response due to federation timing. This causes a crash:

```
TypeError: Cannot read properties of undefined (reading 'name')
  at StructureAPI.project (structure-api.mjs:209)
```

The join itself succeeds — the error only affects the `project()` call immediately after.

## Fix

When the space room is missing from the sync response, fall back to the hierarchy API response (which is already fetched at that point). Name and topic are always available there. `powerlevel` and `encryption` will be `undefined`/`null` in the fallback case but resolve correctly on the next regular sync cycle.

## Testing

- 68 unit tests passing
- Manually verified: federation join between matrix.org and syncpoint.io works without console error