### PR TITLE
fix: ensure post() completes before shareHistoricalKeys()

### DIFF
--- a/src/command-api.mjs
+++ b/src/command-api.mjs
@@ -23,16 +23,16 @@ class CommandAPI {
    *
    * There is no way to retrieve the returning result of that function.
    */
-  schedule (functionCall) {
+  async schedule (functionCall) {
     const [functionName] = functionCall
     // Allow scheduling async callback functions directly
     if (typeof functionName === 'function') {
-      this.scheduledCalls.enqueue(functionCall)
+      await this.scheduledCalls.enqueue(functionCall)
       return
     }
     if (!this.httpAPI[functionName]) throw new Error(`HttpAPI: property ${functionName} does not exist`)
     if (typeof this.httpAPI[functionName] !== 'function') throw new Error(`HttpAPI: ${functionName} is not a function`)
-    this.scheduledCalls.enqueue(functionCall)
+    await this.scheduledCalls.enqueue(functionCall)
   }
 
 

--- a/src/project.mjs
+++ b/src/project.mjs
@@ -189,11 +189,11 @@ Project.prototype.joinLayer = async function (layerId) {
  *
  * @param {string} layerId - the local layer id
  */
-Project.prototype.shareHistoricalKeys = function (layerId) {
+Project.prototype.shareHistoricalKeys = async function (layerId) {
   if (!this.crypto.isEnabled) return
   const roomId = this.idMapping.get(layerId)
   if (!roomId) return
-  this.commandAPI.schedule([async () => {
+  await this.commandAPI.schedule([async () => {
     const myUserId = this.timelineAPI.credentials().user_id
     const projectRoomId = this.idMapping.get(this.projectId)
     const allMembers = await this.memberCache.getMembers(projectRoomId)
@@ -254,7 +254,7 @@ Project.prototype.content = async function (layerId, from) {
 }
 
 Project.prototype.post = async function (layerId, operations) {
-  this.__post(layerId, operations, ODINv2_MESSAGE_TYPE)
+  await this.__post(layerId, operations, ODINv2_MESSAGE_TYPE)
 }
 
 Project.prototype.__post = async function (layerId, operations, messageType) {
@@ -279,7 +279,9 @@ Project.prototype.__post = async function (layerId, operations, messageType) {
   const parts = collect(chunks)
 
   const upstreamId = this.idMapping.get(layerId)
-  parts.forEach(part => this.commandAPI.schedule(['sendMessageEvent', upstreamId, messageType, { content: encode(part) }]))
+  for (const part of parts) {
+    await this.commandAPI.schedule(['sendMessageEvent', upstreamId, messageType, { content: encode(part) }])
+  }
 }
 
 Project.prototype.start = async function (streamToken, handler = {}) {


### PR DESCRIPTION
## Problem

When sharing an E2EE layer, `shareHistoricalKeys()` found 0 Megolm session keys to share — even though content had just been posted. This meant new members joining the layer had no keys and couldn't decrypt content until the safety-net mechanism fired (requiring the sharing member to be online).

## Root Cause

`post()` did not `await` its internal `__post()` call:

```js
Project.prototype.post = async function (layerId, operations) {
  this.__post(layerId, operations, ODINv2_MESSAGE_TYPE)  // ← missing await!
}
```

So ODIN's share handler sequence:
```js
await replicatedProject.post(id, operations)        // returned immediately!
await replicatedProject.shareHistoricalKeys(id)      // ran before posts were enqueued
```

The `shareHistoricalKeys` callback was enqueued in the command queue **before** the content chunks, ran first, and found no Megolm sessions yet.

## Fix

- `post()` now awaits `__post()`
- `__post()` uses `for..of` instead of `forEach` to serialize chunk scheduling
- `shareHistoricalKeys()` is now async, awaits `schedule()`
- `schedule()` is now async, awaits `enqueue()` to guarantee FIFO insertion order

## Testing

- 68 unit tests passing
- Manual testing: B shares layer → keys shared immediately → A joins (B offline) → content decrypted instantly ✅